### PR TITLE
Run job as non-privileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,13 @@ RUN apt update \
     && apt install -y software-properties-common \
     && add-apt-repository -y ppa:ondrej/php \
     && apt install -y \
-        wget \
         git \
-        yamllint \
-        npm \
         jq \
         libzip-dev \
+        npm \
+        sudo \
+        wget \
+        yamllint \
         zip \
         php5.6-cli \
         php5.6-bz2 \
@@ -125,5 +126,7 @@ RUN composer global require staabm/annotate-pull-request-from-checkstyle \
     && ln -s $(composer config --global home)/vendor/bin/cs2pr /usr/local/bin/cs2pr
 
 ADD entrypoint.sh /usr/local/bin/entrypoint.sh
+
+RUN useradd -ms /bin/bash testuser
 
 ENTRYPOINT ["entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -139,5 +139,7 @@ if [[ "${COMMAND}" =~ markdownlint ]];then
     fi
 fi
 
+chown -R testuser .
+
 echo "Running ${COMMAND}"
-eval ${COMMAND}
+sudo -u testuser ${COMMAND}


### PR DESCRIPTION
We occasionally have test cases that are checking for the ability to do things like write to non-writeable files.

The standard image runs as the root user, which is needed to ensure we can install extensions, update configuration, set the preferred PHP version, etc.

However, the root user can _always_ write to files.

There are tools, such as `chattr +i <filename>` that can mark a file immutable, but these are **disabled in Docker**.

As such, the solution I came up with is to:

- Add a "testuser" account
- Add the "sudo" package
- In the entrypoint:
  - change ownership of the workdir and its contents to testuser
  - run the command as testuser

This resolves the testing issues, while retaining the original functionality.
