### PR TITLE
Perform an apt update before installing extensions

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -111,6 +111,7 @@ DEPS=$(echo "${JOB}" | jq -r '.dependencies')
 
 if [[ "${EXTENSIONS}" != "" ]];then
     echo "Installing extensions"
+    apt update
     apt install -y ${EXTENSIONS}
 fi
 


### PR DESCRIPTION
When extensions are specified, if we do not perform an `apt update`, and the packages are out-of-date, the `apt install` operation to install the related package extension will fail.

This patch adds an `apt update` step prior to installing any extensions.
