### PR TITLE
Allow jobs to run pre/post command scripts

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -145,5 +145,25 @@ fi
 
 chown -R testuser .
 
+# Is there a pre-run script available?
+if [ -x ".laminas-ci/pre-run.sh" ];then
+    echo "Executing pre-run commands from .laminas-ci/pre-run.sh"
+    ./.laminas-ci/pre-run.sh testuser "${PWD}" "${JOB}"
+fi
+
+# Disable exit-on-non-zero flag so we can run post-commands
+set +e
+
 echo "Running ${COMMAND}"
 sudo -u testuser /bin/bash -c "${COMMAND}"
+STATUS=$?
+
+set -e
+
+# Is there a post-run script available?
+if [ -x ".laminas-ci/post-run.sh" ];then
+    echo "Executing post-run commands from .laminas-ci/post-run.sh"
+    ./.laminas-ci/post-run.sh "${STATUS}" testuser "${PWD}" "${JOB}"
+fi
+
+exit ${STATUS}


### PR DESCRIPTION
This patch modifies the `entrypoint.sh` to run, if present and executable, pre and post scripts located at:

- `.laminas-ci/pre-run.sh`
- `.laminas-ci/post-run.sh`

The QA command itself is now run without the "exit on non-zero status" flag, and the status captured (and used as the return value later).

The `.laminas-ci/pre-run.sh` script receives the arguments:

- `$1`: the user the QA command runs under
- `$2`: the WORKDIR path
- `$3`: the `$JOB` passed to the entrypoint

The `.laminas-ci/post-run.sh` script receives the arguments:

- `$1`: the exit status of the QA command
- `$2`: the user the QA command runs under
- `$3`: the WORKDIR path
- `$4`: the `$JOB` passed to the entrypoint

I've tested this successfully in laminas-http: https://github.com/laminas/laminas-http/actions/runs/579221024
