### PR TITLE
Make checkout more flexible

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,11 +18,21 @@ function help {
 function checkout {
     local REF=
     local LOCAL_BRANCH=
+
+    if [[ ! $GITHUB_EVENT_NAME || ! $GITHUB_REPOSITORY || ! $GITHUB_REF ]];then
+        return
+    fi
+
     case $GITHUB_EVENT_NAME in
         pull_request)
             REF=$GITHUB_REF
             LOCAL_BRANCH=$GITHUB_HEAD_REF
             BASE_BRANCH=$GITHUB_BASE_REF
+
+            if [[ ! $LOCAL_BRANCH || ! $BASE_BRANCH ]]; then
+                echo "Missing head or base ref env variables; aborting"
+                exit 1
+            fi
             ;;
         push)
             REF=${GITHUB_REF/refs\/heads\//}
@@ -37,8 +47,17 @@ function checkout {
             exit 1
     esac
 
-    echo "Cloning repository"
-    git clone https://github.com/"${GITHUB_REPOSITORY}" .
+    if [ -d ".git" ];then
+        echo "Updating and fetching from canonical repository"
+        if [[ $(git remote) =~ origin ]];then
+            git remote remove origin
+        fi
+        git remote add origin https://github.com/"${GITHUB_REPOSITORY}"
+        git fetch origin
+    else
+        echo "Cloning repository"
+        git clone https://github.com/"${GITHUB_REPOSITORY}" .
+    fi
 
     if [[ "$REF" == "$LOCAL_BRANCH" ]];then
         echo "Checking out ref ${REF}"


### PR DESCRIPTION
When testing locally, we can explicitly set the workdir to the current checkout, which means no checkout is really required.
As such, we can omit the various `$GITHUB_*` env variables when invoking the container, and simplify usage.
The first conditional in the updated `checkout()` function does this for us, and the conditional within the `pull_request` case acts as an extra safeguard.
Example of such usage:

```bash
docker run -v $(realpath .):/github/workspace -w=/github/workspace laminas-check-runner:latest '{"php":"7.4","deps":"latest","extensions":[],"ini":["memory_limit=-1"],"command":"./vendor/bin/phpunit"}'
```

When testing as part of a local action, where we might want to change the entrypoint, we need to first run `actions/checkout`, which mans we already have a checkout; performing a clone into the workdir thus raises an error.
To make this usage work, I added the `if [ -d ".git" ];then` conditional, which adds the "origin" remote and points it at the canonical repository (removing the remote first if it already exists), and the fetches it so we get history.

(I will likely port this to the laminas-ci-matrix-container as well.)
