### PR TITLE
Install sqlsrv and pdo_sqlsrv extensions for PHP 7.3, 7.4, and 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ The container provides the following tools:
 
 - The [jq](https://stedolan.github.io/jq/) command, a CLI JSON processor.
 
+## Additional extensions
+
+Some extensions are not available via the sury repository.
+The following is a list of additional extensions that are immediately available (without requiring invoking `pecl` in a `pre-run.sh` script), at the specified versions:
+
+- sqlsrv and pdo_sqlsrv: 5.9.0
+
 ## Pre/Post commands
 
 Some packages may require additional setup steps: setting up a web server to test an HTTP client, seeding a database or cache service, etc.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -129,7 +129,16 @@ INI=$(echo "${JOB}" | jq -r '.ini | join("\n")')
 DEPS=$(echo "${JOB}" | jq -r '.dependencies')
 
 if [[ "${EXTENSIONS}" != "" ]];then
-    echo "Installing extensions"
+	if [[ "${EXTENSIONS}" =~ sqlsrv ]];then
+		if [[ ! ${PHP} =~ (7.3|7.4|8.0) ]];then
+			echo "Skipping enabling of sqlsrv extensions; not supported on PHP < 7.3"
+		else
+			echo "Enabling sqlsrv extensions"
+			phpenmod -v ${PHP} -s ALL sqlsrv
+		fi
+		EXTENSIONS=$(echo ${EXTENSIONS} | sed -E -e 's/php[0-9.]+-(pdo[_-]){0,1}sqlsrv/ /g' | sed -E -e 's/\s{2,}/ /g')
+	fi
+    echo "Installing extensions: ${EXTENSIONS}"
     apt update
     apt install -y ${EXTENSIONS}
 fi

--- a/sqlsrv.ini
+++ b/sqlsrv.ini
@@ -1,0 +1,4 @@
+; configuration for php sqlsrv module
+; priority=20
+extension=sqlsrv.so
+extension=pdo_sqlsrv.so


### PR DESCRIPTION
The 5.9.0 version of the MS sqlsrv extensions provides support for Ubuntu 20.04, for PHP versions 7.3, 7.4, and 8.0.  The require the msodbcsql17 libraries from the MS DEB repository, but are themselves shipped as binaries via GitHub.  This patch adds the MS DEB repo to the container, installs msodbcsql17, and pulls the sqlsrv and pdo-sqlsrv extensions for each of PHP 7.3, 7.4, and 8.0 from GitHub, installing them in the appropriate extension library directory for each version.  It adds configuration to the `mods-available` directory of each PHP version.  The `entrypoint.sh` is altered to look for any references to sqlsrv extensions, and, when discovered:

- Emits a notice on PHP versions < 7.3 indicating it cannot be enabled
- Uses `phpenmod` to enable the sqlsrv configuration for the requested PHP version
